### PR TITLE
changed how order time is handled to fix am/pm and 0 for 12:00

### DIFF
--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -43,7 +43,13 @@ module.exports = {
     let meridian = 'AM';
     if (hours > 12) {
       hours -= 12;
+    }
+    if (hours >=12) {
       meridian = 'PM';
+    }
+
+    if (hours == 0) {
+      hours = 12
     }
 
     let minutes = newDateObj.getMinutes();
@@ -56,8 +62,14 @@ module.exports = {
     let meridian = 'AM';
     if (hours > 12) {
       hours -= 12;
+    }
+    if (hours >= 12) {
       meridian = 'PM';
     }
+    if (hours == 0) {
+      hours = 12;
+    }
+
     let minutes = newDateObj.getMinutes();
     return `${hours}:${minutes.toString().padStart(2, 0)} ${meridian}`;
   },
@@ -68,8 +80,14 @@ module.exports = {
     let meridian = 'AM';
     if (hours > 12) {
       hours -= 12;
+    }
+    if (hours >= 12) {
       meridian = 'PM';
     }
+    if (hours == 0) {
+      hours = 12;
+    }
+
     let minutes = newDateObj.getMinutes();
     return `${hours}:${minutes.toString().padStart(2, 0)} ${meridian}`;
   }


### PR DESCRIPTION
Just changed the helper functions for display the order/delivery times. It was showing 0:XX for midnight and am/pm was not handled correctly.